### PR TITLE
Fix author name parsing in fetch_doi_tips

### DIFF
--- a/src/teachbooks_sphinx_tippy.py
+++ b/src/teachbooks_sphinx_tippy.py
@@ -604,8 +604,13 @@ def fetch_doi_tips(app: Sphinx, data: dict[str, TippyPageData]) -> dict[str, str
                 title = [data['metadata']['title']]
                 authors = data['metadata']['creators']
                 for author in authors:
-                    author["given"] = author['name'].split(",")[1].strip()
-                    author['family'] = author['name'].split(",")[0].strip()
+                    parts_name = author['name'].split(",")
+                    if len(parts_name)>1:
+                        author["given"] = parts_name[1].strip()
+                        author['family'] = parts_name[0].strip()
+                    else:
+                        author["family"] = parts_name[0].strip()
+                        author['given'] = ""
                 try:
                     publisher = data["metadata"]['publisher']
                 except:


### PR DESCRIPTION
This pull request makes a small but important improvement to the way author names are parsed in the `fetch_doi_tips` function. The code now safely handles cases where the author's name may not contain a comma, preventing potential errors when splitting the name.

- Improved parsing of author names in the `fetch_doi_tips` function in `src/teachbooks_sphinx_tippy.py` to handle cases where the name does not include a comma, ensuring that the `given` and `family` fields are always set without causing an error.